### PR TITLE
Add .dockerignore so it will work with zeit now

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.gitignore


### PR DESCRIPTION
* To use with zeit now (https://zeit.co/now) which allows
  cloud deployment from the command-line without installing
  virtualbox
  1) install now client (https://zeit.co/download)
  2) run 'now --public'
     a) will prompt for email
     b) go to email to validate your email
  3) wait for docker container to build (about 3-7 minutes)
  4) go to url (display in output, copied to clipboard on some OSes)